### PR TITLE
Fix multiple value env vars

### DIFF
--- a/source/cli.js
+++ b/source/cli.js
@@ -200,6 +200,7 @@ async function main () {
     .config()
     .version()
     .help()
+    .wrap(null)
 
   const configuration = parseOptions(splitOptions(argv))
 

--- a/source/cli.js
+++ b/source/cli.js
@@ -13,8 +13,12 @@ function splitOptions (configuration) {
   for (const array of arrays) {
     const split = []
     for (const items of configuration[array]) {
-      for (const item of items.split(' ')) {
-        split.push(item)
+      if (typeof items === 'string') {
+        for (const item of items.split(' ')) {
+          split.push(item)
+        }
+      } else {
+        split.push(items)
       }
     }
     configuration[array] = split

--- a/source/cli.js
+++ b/source/cli.js
@@ -242,6 +242,7 @@ async function main () {
 
 main()
   .catch((error) => {
-    console.trace(chalk.red(error))
+    error.message = chalk.red(error.message)
+    console.trace(error)
     process.exit(1)
   })

--- a/source/cli.js
+++ b/source/cli.js
@@ -6,24 +6,16 @@ const yargs = require('yargs')
 const chalk = require('chalk')
 const { platform } = require('os')
 
-// TODO: yargs support for array type options with environment variables
-// https://github.com/yargs/yargs/issues/821
-function splitOptions (configuration) {
-  const arrays = ['doh', 'listen', 'countermeasures', 'bootstrap']
-  for (const array of arrays) {
-    const split = []
-    for (const items of configuration[array]) {
-      if (typeof items === 'string') {
-        for (const item of items.split(' ')) {
-          split.push(item)
-        }
-      } else {
-        split.push(items)
-      }
+function splitStrings (array) {
+  const values = []
+  for (const value of array) {
+    if (typeof value === 'string') {
+      values.push(...value.split(/\s+/))
+    } else {
+      values.push(value)
     }
-    configuration[array] = split
   }
-  return configuration
+  return values
 }
 
 function parseOptions ({
@@ -114,12 +106,14 @@ async function main () {
   const { argv } = yargs
     .env('DOHNUT')
     .option('doh', {
+      coerce: splitStrings,
       type: 'array',
       alias: ['upstream', 'proxy'],
       describe: 'URI Templates or shortnames of upstream DNS over HTTPS resolvers',
       default: []
     })
     .option('listen', {
+      coerce: splitStrings,
       type: 'array',
       alias: ['local', 'l'],
       describe: 'IPs and ports for the local DNS server',
@@ -139,12 +133,14 @@ async function main () {
       default: 'performance'
     })
     .option('countermeasures', {
+      coerce: splitStrings,
       type: 'array',
       describe: 'Special tactics to protect your privacy',
       choices: ['spoof-queries', 'spoof-useragent'],
       default: []
     })
     .option('bootstrap', {
+      coerce: splitStrings,
       type: 'array',
       describe: 'IP addresses of DNS servers used to resolve the DoH URI hostname',
       default: []
@@ -202,7 +198,7 @@ async function main () {
     .help()
     .wrap(null)
 
-  const configuration = parseOptions(splitOptions(argv))
+  const configuration = parseOptions(argv)
 
   if (argv.test) {
     console.log('Configuration is valid')


### PR DESCRIPTION
This uses Yargs' [coerce](http://yargs.js.org/docs/#api-coercekey-fn) feature to split multiple whitespace-separated values passed as concatenated environment variable strings.

No more need for the post-processing hack.

Also, sort of related:
- Turn off wrapping to make CLI help output easier to read.
- Show the full depth error call stack trace to pin-point thrown errors.

Fixes #22 
Workaround for https://github.com/yargs/yargs/issues/821